### PR TITLE
Add a hashed author slug

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -42,6 +42,7 @@ function ba_eas_show_user_nicename( $user ) {
 		'firstlast'   => ba_eas_get_nicename_by_structure( $user->ID, 'firstlast' ),
 		'lastfirst'   => ba_eas_get_nicename_by_structure( $user->ID, 'lastfirst' ),
 		'userid'      => ba_eas_get_nicename_by_structure( $user->ID, 'userid' ),
+		'hash'        => ba_eas_get_nicename_by_structure( $user->ID, 'hash' ),
 	);
 
 	/**
@@ -899,7 +900,8 @@ function ba_eas_default_user_nicename_options_list() {
 			'lastname'    => __( 'lastname', 'edit-author-slug' ),
 			'firstlast'   => __( 'firstname-lastname', 'edit-author-slug' ),
 			'lastfirst'   => __( 'lastname-firstname', 'edit-author-slug' ),
-			'userid'      => __( 'userid (Experimental)', 'edit-author-slug' ),
+			'userid'      => __( 'userid', 'edit-author-slug' ),
+			'hash'        => __( 'hash', 'edit-author-slug' ),
 		)
 	);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -467,7 +467,7 @@ function ba_eas_get_nicename_by_structure( $user_id = 0, $structure = '' ) {
 			break;
 
 		case 'hash':
-			$nicename = wp_hash( $user->ID . '-' . $user->user_login );
+			$nicename = hash( 'md5', $user->ID . '-' . $user->user_login );
 			break;
 	} // End switch.
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -467,7 +467,7 @@ function ba_eas_get_nicename_by_structure( $user_id = 0, $structure = '' ) {
 			break;
 
 		case 'hash':
-			$nicename = wp_hash( $user->ID . $user->user_login . $user->user_email );
+			$nicename = wp_hash( $user->ID . '-' . $user->user_login );
 			break;
 	} // End switch.
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -465,6 +465,10 @@ function ba_eas_get_nicename_by_structure( $user_id = 0, $structure = '' ) {
 		case 'userid':
 			$nicename = $user->ID;
 			break;
+
+		case 'hash':
+			$nicename = wp_hash( $user->ID . $user->user_login . $user->user_email );
+			break;
 	} // End switch.
 
 	// Sanitize and trim the new user nicename.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -467,7 +467,7 @@ function ba_eas_get_nicename_by_structure( $user_id = 0, $structure = '' ) {
 			break;
 
 		case 'hash':
-			$nicename = hash( 'md5', $user->ID . '-' . $user->user_login );
+			$nicename = hash( 'sha1', $user->ID . '-' . $user->user_login );
 			break;
 	} // End switch.
 

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -1044,14 +1044,15 @@ class BA_EAS_Tests_Admin extends WP_UnitTestCase {
 	 */
 	public function test_ba_eas_default_user_nicename_options_list() {
 		$options = array(
-			'username'    => __( 'username (Default)',    'edit-author-slug' ),
-			'nickname'    => __( 'nickname',              'edit-author-slug' ),
-			'displayname' => __( 'displayname',           'edit-author-slug' ),
-			'firstname'   => __( 'firstname',             'edit-author-slug' ),
-			'lastname'    => __( 'lastname',              'edit-author-slug' ),
-			'firstlast'   => __( 'firstname-lastname',    'edit-author-slug' ),
-			'lastfirst'   => __( 'lastname-firstname',    'edit-author-slug' ),
-			'userid'      => __( 'userid (Experimental)', 'edit-author-slug' ),
+			'username'    => __( 'username (Default)', 'edit-author-slug' ),
+			'nickname'    => __( 'nickname', 'edit-author-slug' ),
+			'displayname' => __( 'displayname', 'edit-author-slug' ),
+			'firstname'   => __( 'firstname', 'edit-author-slug' ),
+			'lastname'    => __( 'lastname', 'edit-author-slug' ),
+			'firstlast'   => __( 'firstname-lastname', 'edit-author-slug' ),
+			'lastfirst'   => __( 'lastname-firstname', 'edit-author-slug' ),
+			'userid'      => __( 'userid', 'edit-author-slug' ),
+			'hash'        => __( 'hash', 'edit-author-slug' ),
 		);
 
 		$this->assertSame( $options, ba_eas_default_user_nicename_options_list() );

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -587,7 +587,7 @@ class BA_EAS_Tests_Functions extends WP_UnitTestCase {
 		$hash = ba_eas_get_nicename_by_structure( self::$user_id, 'hash' );
 		$user = get_userdata( self::$user_id );
 		$this->assertEquals(
-			wp_hash( $user->ID . '-' . $user->user_login ),
+			hash( 'md5', $user->ID . '-' . $user->user_login ),
 			$hash
 		);
 	}

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -583,6 +583,13 @@ class BA_EAS_Tests_Functions extends WP_UnitTestCase {
 
 		$userid = ba_eas_get_nicename_by_structure( self::$user_id, 'userid' );
 		$this->assertEquals( self::$user_id, $userid );
+
+		$hash = ba_eas_get_nicename_by_structure( self::$user_id, 'hash' );
+		$userdata = get_userdata( self::$user_id );
+		$this->assertEquals(
+			wp_hash( $userdata->ID . $userdata->user_login . $userdata->user_email ),
+			$hash
+		);
 	}
 
 	/**

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -587,7 +587,7 @@ class BA_EAS_Tests_Functions extends WP_UnitTestCase {
 		$hash = ba_eas_get_nicename_by_structure( self::$user_id, 'hash' );
 		$user = get_userdata( self::$user_id );
 		$this->assertEquals(
-			hash( 'md5', $user->ID . '-' . $user->user_login ),
+			hash( 'sha1', $user->ID . '-' . $user->user_login ),
 			$hash
 		);
 	}

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -585,9 +585,9 @@ class BA_EAS_Tests_Functions extends WP_UnitTestCase {
 		$this->assertEquals( self::$user_id, $userid );
 
 		$hash = ba_eas_get_nicename_by_structure( self::$user_id, 'hash' );
-		$userdata = get_userdata( self::$user_id );
+		$user = get_userdata( self::$user_id );
 		$this->assertEquals(
-			wp_hash( $userdata->ID . $userdata->user_login . $userdata->user_email ),
+			wp_hash( $user->ID . '-' . $user->user_login ),
 			$hash
 		);
 	}


### PR DESCRIPTION
Adds a hash as an option for author slugs. The hash is based on the user id, the username, and the user email address. This should be sufficient in creating a unique string every time.

Fixes #17